### PR TITLE
`Wordpress` -> `WordPress`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Next.js Starter for Wordpress Headless CMS
+# Next.js Starter for WordPress Headless CMS
 
-![Wordpress_Next_js Starter by 9d8](https://github.com/9d8dev/next-wp/assets/57158102/76daa171-d286-4bd7-ae72-837c0d911f7a)
+![WordPress_Next_js Starter by 9d8](https://github.com/9d8dev/next-wp/assets/57158102/76daa171-d286-4bd7-ae72-837c0d911f7a)
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2F9d8dev%2Fnext-wp&env=WORDPRESS_URL,WORDPRESS_HOSTNAME&envDescription=Add%20Wordpress%20URL%20with%20Rest%20API%20enabled%20(ie.%20https%3A%2F%2Fwp.example.com)%20abd%20the%20hostname%20for%20Image%20rendering%20in%20Next%20JS%20(ie.%20wp.example.com)&project-name=next-wp&repository-name=next-wp&demo-title=Next%20JS%20and%20WordPress%20Starter&demo-url=https%3A%2F%2Fwp.9d8.dev)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2F9d8dev%2Fnext-wp&env=WORDPRESS_URL,WORDPRESS_HOSTNAME&envDescription=Add%20WordPress%20URL%20with%20Rest%20API%20enabled%20(ie.%20https%3A%2F%2Fwp.example.com)%20abd%20the%20hostname%20for%20Image%20rendering%20in%20Next%20JS%20(ie.%20wp.example.com)&project-name=next-wp&repository-name=next-wp&demo-title=Next%20JS%20and%20WordPress%20Starter&demo-url=https%3A%2F%2Fwp.9d8.dev)
 
 This is a starter template for building a Next.js application that fetches data from a WordPress site using the WordPress REST API. The template includes functions for fetching posts, categories, tags, authors, and featured media from a WordPress site and rendering them in a Next.js application.
 
@@ -10,10 +10,10 @@ This is a starter template for building a Next.js application that fetches data 
 
 ## Table of Contents
 
-- [Next.js Starter for Wordpress Headless CMS](#nextjs-starter-for-wordpress-headless-cms)
+- [Next.js Starter for WordPress Headless CMS](#nextjs-starter-for-wordpress-headless-cms)
   - [Table of Contents](#table-of-contents)
   - [Overview](#overview)
-  - [Wordpress Functions](#wordpress-functions)
+  - [WordPress Functions](#wordpress-functions)
   - [WordPress Types](#wordpress-types)
   - [Post Card Component](#post-card-component)
     - [Props](#props)
@@ -39,7 +39,7 @@ WORDPRESS_HOSTNAME="wordpress.com"
 
 You can find the example of `.env.local` file in the `.env.example` file (and in Vercel):
 
-## Wordpress Functions
+## WordPress Functions
 
 The `lib/wordpress.ts` file contains several functions for fetching data from a WordPress site using the WordPress REST API. Here's a brief overview of each function:
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,9 +25,9 @@ const fontSans = FontSans({
 });
 
 export const metadata: Metadata = {
-  title: "Wordpress/Next.js Starter by 9d8",
+  title: "WordPress/Next.js Starter by 9d8",
   description:
-    "A starter template for Next.js with Wordpress as a headless CMS.",
+    "A starter template for Next.js with WordPress as a headless CMS.",
   metadataBase: new URL("https://wp.9d8.dev"),
 };
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -32,7 +32,7 @@ const ExampleJsx = () => {
       {/* Vercel Clone Starter */}
       <a
         className="h-16 block"
-        href="https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2F9d8dev%2Fnext-wp&env=WORDPRESS_URL,WORDPRESS_HOSTNAME&envDescription=Add%20Wordpress%20URL%20with%20Rest%20API%20enabled%20(ie.%20https%3A%2F%2Fwp.example.com)%20abd%20the%20hostname%20for%20Image%20rendering%20in%20Next%20JS%20(ie.%20wp.example.com)&project-name=next-wp&repository-name=next-wp&demo-title=Next%20JS%20and%20WordPress%20Starter&demo-url=https%3A%2F%2Fwp.9d8.dev"
+        href="https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2F9d8dev%2Fnext-wp&env=WORDPRESS_URL,WORDPRESS_HOSTNAME&envDescription=Add%20WordPress%20URL%20with%20Rest%20API%20enabled%20(ie.%20https%3A%2F%2Fwp.example.com)%20abd%20the%20hostname%20for%20Image%20rendering%20in%20Next%20JS%20(ie.%20wp.example.com)&project-name=next-wp&repository-name=next-wp&demo-title=Next%20JS%20and%20WordPress%20Starter&demo-url=https%3A%2F%2Fwp.9d8.dev"
       >
         {/* eslint-disable-next-line */}
         <img

--- a/lib/wordpress.ts
+++ b/lib/wordpress.ts
@@ -1,5 +1,5 @@
-// Description: Wordpress API functions
-// Used to fetch data from a Wordpress site using the Wordpress REST API
+// Description: WordPress API functions
+// Used to fetch data from a WordPress site using the WordPress REST API
 // Types are imported from `wp.d.ts`
 
 import {
@@ -11,11 +11,11 @@ import {
   FeaturedMedia,
 } from "./wordpress.d";
 
-// Wordpress Config
+// WordPress Config
 
 const url = process.env.WORDPRESS_URL;
 
-// Wordpress Functions
+// WordPress Functions
 
 export async function getAllPosts(filterParams?: {
   author?: string;


### PR DESCRIPTION
sorry for being that annoying person that opens a fix typo PR but as an [Automattician](https://automattic.com/) i'm contractually obligated* to fix spelling of WordPress wherever i might see it!

*not really

great project btw!