### PR TITLE
chore: refactored to reduce repetition

### DIFF
--- a/lib/wordpress.ts
+++ b/lib/wordpress.ts
@@ -17,10 +17,11 @@ import {
 
 const baseUrl = process.env.WORDPRESS_URL;
 
-function getUrl(path: string, query?: Record<string, any>) {
-    const params = query ? querystring.stringify(query) : null
-  
-    return `${baseUrl}${path}${params ? `?${params}` : ""}`
+function wpFetch<T>(path: string, query?: Record<string, any>) {
+  const url = `${baseUrl}${path}${query ? `?${querystring.stringify(query)}` : ""}`;
+
+  return fetch(url)
+    .then(response => response.json()) as Promise<T>;
 }
 
 // WordPress Functions
@@ -30,169 +31,105 @@ export async function getAllPosts(filterParams?: {
   tag?: string;
   category?: string;
 }): Promise<Post[]> {  
-  const url = getUrl("/wp-json/wp/v2/posts", { author: filterParams?.author, tags: filterParams?.tag, categories: filterParams?.category });
-  const response = await fetch(url);
-  const posts: Post[] = await response.json();
-  return posts;
+  return wpFetch<Post[]>("/wp-json/wp/v2/posts", { author: filterParams?.author, tags: filterParams?.tag, categories: filterParams?.category });
 }
 
 export async function getPostById(id: number): Promise<Post> {
-  const url = getUrl(`/wp-json/wp/v2/posts/${id}`);
-  const response = await fetch(url);
-  const post: Post = await response.json();
-  return post;
+  return wpFetch<Post>(`/wp-json/wp/v2/posts/${id}`);
 }
 
 export async function getPostBySlug(slug: string): Promise<Post> {
-  const url = getUrl("/wp-json/wp/v2/posts", { slug });
-  const response = await fetch(url);
-  const post: Post[] = await response.json();
-  return post[0];
+  return wpFetch<Post[]>("/wp-json/wp/v2/posts", { slug })
+    .then(posts => posts[0]);
 }
 
 export async function getAllCategories(): Promise<Category[]> {
-  const url = getUrl("/wp-json/wp/v2/categories");
-  const response = await fetch(url);
-  const categories: Category[] = await response.json();
-  return categories;
+  return wpFetch<Category[]>("/wp-json/wp/v2/categories");
 }
 
 export async function getCategoryById(id: number): Promise<Category> {
-  const url = getUrl(`/wp-json/wp/v2/categories/${id}`);
-  const response = await fetch(url);
-  const category: Category = await response.json();
-  return category;
+  return wpFetch<Category>(`/wp-json/wp/v2/categories/${id}`);
 }
 
 export async function getCategoryBySlug(slug: string): Promise<Category> {
-  const url = getUrl("/wp-json/wp/v2/categories", { slug });
-  const response = await fetch(url);
-  const category: Category[] = await response.json();
-  return category[0];
+  return wpFetch<Category[]>("/wp-json/wp/v2/categories", { slug })
+    .then(categories => categories[0]);
 }
 
 export async function getPostsByCategory(categoryId: number): Promise<Post[]> {
-  const url = getUrl("/wp-json/wp/v2/posts", { categories:  categoryId });
-  const response = await fetch(url);
-  const posts: Post[] = await response.json();
-  return posts;
+  return wpFetch<Post[]>("/wp-json/wp/v2/posts", { categories:  categoryId });
 }
 
 export async function getPostsByTag(tagId: number): Promise<Post[]> {
-  const url = getUrl("/wp-json/wp/v2/posts", { tags:  tagId });
-  const response = await fetch(url);
-  const posts: Post[] = await response.json();
-  return posts;
+  return wpFetch<Post[]>("/wp-json/wp/v2/posts", { tags:  tagId });
 }
 
 export async function getTagsByPost(postId: number): Promise<Tag[]> {
-  const url = getUrl("/wp-json/wp/v2/tags", { post:  postId });
-  const response = await fetch(url);
-  const tags: Tag[] = await response.json();
-  return tags;
+  return wpFetch<Tag[]>("/wp-json/wp/v2/tags", { post:  postId });
 }
 
 export async function getAllTags(): Promise<Tag[]> {
-  const url = getUrl("/wp-json/wp/v2/tags");
-  const response = await fetch(url);
-  const tags: Tag[] = await response.json();
-  return tags;
+  return wpFetch<Tag[]>("/wp-json/wp/v2/tags");
 }
 
 export async function getTagById(id: number): Promise<Tag> {
-  const url = getUrl(`/wp-json/wp/v2/tags/${id}`);
-  const response = await fetch(url);
-  const tag: Tag = await response.json();
-  return tag;
+  return wpFetch<Tag>(`/wp-json/wp/v2/tags/${id}`);
 }
 
 export async function getTagBySlug(slug: string): Promise<Tag> {
-  const url = getUrl("/wp-json/wp/v2/tags", { slug });
-  const response = await fetch(url);
-  const tag: Tag[] = await response.json();
-  return tag[0];
+  return wpFetch<Tag[]>("/wp-json/wp/v2/tags", { slug })
+    .then(tags => tags[0]);
 }
 
 export async function getAllPages(): Promise<Page[]> {
-  const url = getUrl("/wp-json/wp/v2/pages");
-  const response = await fetch(url);
-  const pages: Page[] = await response.json();
-  return pages;
+  return wpFetch<Page[]>("/wp-json/wp/v2/pages");
 }
 
 export async function getPageById(id: number): Promise<Page> {
-  const url = getUrl(`/wp-json/wp/v2/pages/${id}`);
-  const response = await fetch(url);
-  const page: Page = await response.json();
-  return page;
+  return wpFetch<Page>(`/wp-json/wp/v2/pages/${id}`);
 }
 
 export async function getPageBySlug(slug: string): Promise<Page> {
-  const url = getUrl("/wp-json/wp/v2/pages", { slug });
-  const response = await fetch(url);
-  const page: Page[] = await response.json();
-  return page[0];
+  return wpFetch<Page[]>("/wp-json/wp/v2/pages", { slug })
+    .then(pages => pages[0]);
 }
 
 export async function getAllAuthors(): Promise<Author[]> {
-  const url = getUrl("/wp-json/wp/v2/users");
-  const response = await fetch(url);
-  const authors: Author[] = await response.json();
-  return authors;
+  return wpFetch<Author[]>("/wp-json/wp/v2/users");
 }
 
 export async function getAuthorById(id: number): Promise<Author> {
-  const url = getUrl(`/wp-json/wp/v2/users/${id}`);
-  const response = await fetch(url);
-  const author: Author = await response.json();
-  return author;
+  return wpFetch<Author>(`/wp-json/wp/v2/users/${id}`);
 }
 
 export async function getAuthorBySlug(slug: string): Promise<Author> {
-  const url = getUrl("/wp-json/wp/v2/users", { slug });
-  const response = await fetch(url);
-  const author: Author[] = await response.json();
-  return author[0];
+  return wpFetch<Author[]>("/wp-json/wp/v2/users", { slug })
+    .then(authors => authors[0]);
 }
 
 export async function getPostsByAuthor(authorId: number): Promise<Post[]> {
-  const url = getUrl("/wp-json/wp/v2/posts", { author: authorId });
-  const response = await fetch(url);
-  const posts: Post[] = await response.json();
-  return posts;
+  return wpFetch<Post[]>("/wp-json/wp/v2/posts", { author: authorId });
 }
 
 export async function getPostsByAuthorSlug(
   authorSlug: string
 ): Promise<Post[]> {
   const author = await getAuthorBySlug(authorSlug);
-  const url = getUrl("/wp-json/wp/v2/posts", { author: author.id });
-  const response = await fetch(url);
-  const posts: Post[] = await response.json();
-  return posts;
+  return wpFetch<Post[]>("/wp-json/wp/v2/posts", { author: author.id });
 }
 
 export async function getPostsByCategorySlug(
   categorySlug: string
 ): Promise<Post[]> {
   const category = await getCategoryBySlug(categorySlug);
-  const url = getUrl("/wp-json/wp/v2/posts", { categories: category.id });
-  const response = await fetch(url);
-  const posts: Post[] = await response.json();
-  return posts;
+  return wpFetch<Post[]>("/wp-json/wp/v2/posts", { categories: category.id });
 }
 
 export async function getPostsByTagSlug(tagSlug: string): Promise<Post[]> {
   const tag = await getTagBySlug(tagSlug);
-  const url = getUrl("/wp-json/wp/v2/posts", { tags: tag.id });
-  const response = await fetch(url);
-  const posts: Post[] = await response.json();
-  return posts;
+  return wpFetch<Post[]>("/wp-json/wp/v2/posts", { tags: tag.id });
 }
 
 export async function getFeaturedMediaById(id: number): Promise<FeaturedMedia> {
-  const url = getUrl(`/wp-json/wp/v2/media/${id}`);
-  const response = await fetch(url);
-  const featuredMedia: FeaturedMedia = await response.json();
-  return featuredMedia;
+  return wpFetch<FeaturedMedia>(`/wp-json/wp/v2/media/${id}`);
 }


### PR DESCRIPTION
This is building on top of the `getUrl` extraction. All the code is doing relatively the same thing so I refactored it all into a `wpFetch` wrapper around `fetch`. This drastically reduces the repetitiveness of the code as well as enables a central location to insert error handling, request tracing, etc.

PS. I'm relatively sure the the explicit return types of `Promise<Post>` for instance aren't needed anymore with this implementation, but I kept them there to confirm the contract is maintained since I couldn't find any tests to update.