### PR TITLE
Fix error in post page when no featured image is set

### DIFF
--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -65,7 +65,7 @@ export default async function Page({
 }) {
   const { slug } = await params;
   const post = await getPostBySlug(slug);
-  const featuredMedia = await getFeaturedMediaById(post.featured_media);
+  const featuredMedia = post.featured_media ? await getFeaturedMediaById(post.featured_media) : null;
   const author = await getAuthorById(post.author);
   const date = new Date(post.date).toLocaleDateString("en-US", {
     month: "long",


### PR DESCRIPTION
When accessing a post page without a featured image set, we're getting the following error:

![2025-01-28 at 13 55 27](https://github.com/user-attachments/assets/d8055455-f263-481b-9b96-d501d920bc02)

WP Rest API returns a 0 whenever there's no featured image set, so we need to make sure that post.featured_media is not falsy before invoking getFeaturedMediaById because there's no media with an id of 0, hence the error.