### PR TITLE
fix: resetting page param on filter change

### DIFF
--- a/components/posts/filter.tsx
+++ b/components/posts/filter.tsx
@@ -47,11 +47,9 @@ export function FilterPosts({
   const handleFilterChange = (type: string, value: string) => {
     console.log(`Filter changed: ${type} -> ${value}`);
     const newParams = new URLSearchParams(window.location.search);
-    if (value === "all") {
-      newParams.delete(type);
-    } else {
-      newParams.set(type, value);
-    }
+    newParams.delete("page");
+    value === "all" ? newParams.delete(type) : newParams.set(type, value);
+
     router.push(`/posts?${newParams.toString()}`);
   };
 


### PR DESCRIPTION
This PR addresses the issue where the selected pagination page persists after applying a new filter (as reported in #35). The fix ensures that when filters are changed, the page query parameter is removed,

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Changing filters now always resets pagination, ensuring the page number is cleared whenever a new filter is applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->