### PR TITLE
fix(docker): bump Node to 22 and install mysqlcheck for wp-cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 # Stage 1: Dependencies
-FROM node:20-alpine AS deps
+# Node 22+ is required: corepack installs pnpm@latest (11.x), which depends
+# on the builtin node:sqlite module, only available since Node 22.13.
+FROM node:22-alpine AS deps
 RUN corepack enable && corepack prepare pnpm@latest --activate
 WORKDIR /app
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 
 # Stage 2: Builder
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 RUN corepack enable && corepack prepare pnpm@latest --activate
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
@@ -22,7 +24,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 RUN pnpm build
 
 # Stage 3: Runner
-FROM node:20-alpine AS runner
+FROM node:22-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,8 @@
+allowBuilds:
+  esbuild: true
+  sharp: true
+  unrs-resolver: true
+onlyBuiltDependencies:
+  - esbuild
+  - sharp
+  - unrs-resolver

--- a/wordpress/Dockerfile
+++ b/wordpress/Dockerfile
@@ -10,6 +10,11 @@ RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli
     && chmod +x wp-cli.phar \
     && mv wp-cli.phar /usr/local/bin/wp
 
+# mysqlcheck/mysqldump are required by wp-cli commands like `wp db check` (used in setup.sh)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends default-mysql-client \
+    && rm -rf /var/lib/apt/lists/*
+
 # Copy plugin and theme to staging location (volume overwrites /var/www/html)
 COPY next-revalidate /usr/src/next-revalidate
 COPY theme /usr/src/nextjs-headless


### PR DESCRIPTION
## Summary

Two issues that break the Docker setup as shipped, found while deploying this template as the base for a production self-hosted stack:

- `Dockerfile` pins `node:20-alpine` but installs `pnpm@latest` via corepack (currently resolves to pnpm 11.x), which depends on the builtin `node:sqlite` module — only available since **Node 22.13**. On a clean checkout, `pnpm install --frozen-lockfile` fails unconditionally with `ERR_UNKNOWN_BUILTIN_MODULE`.
- Newer pnpm (10+) blocks postinstall scripts for packages with native binaries (`esbuild`, `sharp`, `unrs-resolver`) unless explicitly allow-listed, and no longer reads the `"pnpm"` field from `package.json` for this — it has to live in `pnpm-workspace.yaml`. Without it, install fails with `ERR_PNPM_IGNORED_BUILDS`.
- `wordpress/Dockerfile`'s `setup.sh` calls `wp db check`, which shells out to the external `mysqlcheck` binary. The `wordpress:latest` base image doesn't include it, so the container hangs forever on `Waiting for database...` even once the database is healthy and reachable.

## Changes

- Bump all three build stages in `Dockerfile` from `node:20-alpine` to `node:22-alpine`.
- Add `pnpm-workspace.yaml` with `allowBuilds`/`onlyBuiltDependencies` for `esbuild`, `sharp`, `unrs-resolver`, and copy it into the `deps` build stage.
- Add `default-mysql-client` to `wordpress/Dockerfile` so `mysqlcheck` is available.

## Test plan

- [x] Clean `docker build` of the root `Dockerfile` from this branch (no other changes) completes successfully and produces a working image.
- [x] Full `docker-compose` stack (web + wordpress + a MariaDB service) built and started end to end; WordPress setup completes instead of looping on "Waiting for database..."; confirmed via `wp plugin list` / `wp theme list` that `next-revalidate` and the headless theme activate correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application containers to use Node.js 22.
  * Enabled required dependency build scripts during installation.
  * Added MySQL client tools to the WordPress container, enabling database checks and backups through WP-CLI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->